### PR TITLE
issue #11

### DIFF
--- a/src/main/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidator.java
+++ b/src/main/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidator.java
@@ -66,6 +66,8 @@ public class PortugueseNIFValidator extends StringValidator {
         float verification = 11-(result%11);
         if (verification > 9) verification = verification%10; 
         
+		if(numbers[8] == 0) return (verification == 1 || verification == 0); 
+        
         return verification == numbers[8]  ;		
 	}
 }

--- a/src/test/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidatorTest.java
+++ b/src/test/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidatorTest.java
@@ -62,6 +62,15 @@ public class PortugueseNIFValidatorTest {
 		assertEquals(0, validatable.getErrors().size());
 	}
 	
+	@Test
+	public void testValidNif0TermWithMod1() {
+		IValidator<String> validator = new PortugueseNIFValidator();
+		
+		Validatable<String> validatable = new Validatable<String>("504646680");
+		validator.validate(validatable);
+		
+		assertEquals(0, validatable.getErrors().size());
+	}
 	
 	@Test
 	public void testInvalidNif() {


### PR DESCRIPTION
It was not taken into account that a NIF ending with 0 will be validated when mod11 results in either 1 or 0. (From the validation section in [this wikipedia page](http://goo.gl/va6n9J).)
