### PR TITLE
make actual validation method public static

### DIFF
--- a/src/main/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidator.java
+++ b/src/main/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidator.java
@@ -47,7 +47,7 @@ public class PortugueseNIFValidator extends StringValidator {
 		}
 	}
 
-	private boolean isNIFValid(String number){
+	public static boolean isNIFValid(String number){
 		// 9 digits required
         if(number.length() != 9) return false;
         // start with 1, 2, 5, 6, 8 or 9


### PR DESCRIPTION
make actual validation method public static, to be accessable to other classes that need NIF validation without needing a wicket validator