### PR TITLE
Updated wicket version to 7.7.0, added fix to avoid new default ajax …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wicket.version>7.2.0</wicket.version>
+		<wicket.version>7.7.0</wicket.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/premiumminds/webapp/wicket/drawer/DrawerManager.java
+++ b/src/main/java/com/premiumminds/webapp/wicket/drawer/DrawerManager.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.head.CssHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
@@ -78,6 +79,11 @@ public class DrawerManager extends Panel {
 				@Override
 				protected void onEvent(AjaxRequestTarget target) {
 					manager.eventPop(ListItem.this.drawer, target);
+				}
+				@Override
+				protected void updateAjaxAttributes(AjaxRequestAttributes attributes) {
+					super.updateAjaxAttributes(attributes);
+					attributes.setPreventDefault(true);
 				}
 			});
 		}


### PR DESCRIPTION
…bubbling behaviour.

Without this the hide-modal event will propagate and close top drawer when called.

Ref: [org.apache.wicket.ajax.attributes.AjaxRequestAttributes#eventPropagation is now BUBBLE by default WICKET-5198](https://cwiki.apache.org/confluence/display/WICKET/Migration+to+Wicket+7.0#MigrationtoWicket7.0-org.apache.wicket.ajax.attributes.AjaxRequestAttributes#eventPropagationisnowBUBBLEbydefaultWICKET-5198)