### PR TITLE
Applied fix to deprecated wicket.properties location according to htt…

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.wicket.IInitializer
+++ b/src/main/resources/META-INF/services/org.apache.wicket.IInitializer
@@ -17,4 +17,4 @@
 # along with pm-wicket-utils. If not, see <http://www.gnu.org/licenses/>.
 #
 
-initializer=com.premiumminds.webapp.wicket.Initializer
+com.premiumminds.webapp.wicket.Initializer


### PR DESCRIPTION
…ps://issues.apache.org/jira/browse/WICKET-5997

Wicket 7 deprecated the wicket.properties file that was used in previous versions.
Clearer explanation of the change needed in:
https://stackoverflow.com/questions/34746771/conflicting-warnings-about-location-of-wicket-properties-in-wicket-7