### PR TITLE
Fix for issue 41

### DIFF
--- a/src/main/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidator.java
+++ b/src/main/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidator.java
@@ -18,9 +18,14 @@
  */
 package com.premiumminds.webapp.wicket.validators;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.ValidationError;
 import org.apache.wicket.validation.validator.StringValidator;
+
+import com.google.common.collect.Lists;
 
 /**
  * Class the validates portuguese NIF numbers
@@ -52,8 +57,14 @@ public class PortugueseNIFValidator extends StringValidator {
 		if(number.length() != 9) {
 			return false;
 		}
-		// start with 1, 2, 5, 6, 8 or 9
-		if(!"125689".contains(Character.toString(number.charAt(0)))){
+		
+		List<Character> firstDigits = Lists.charactersOf("123568");
+		boolean validFirstDigit = firstDigits.stream().map(c -> number.charAt(0) == c).filter(b -> b).findAny().orElse(false);
+
+		List<String> firstDoubleDigits = Lists.newArrayList("45", "70", "71", "72", "74", "75", "77", "79", "90", "91", "98", "99");
+		boolean validDoubleDigits = firstDoubleDigits.stream().map(c -> number.substring(0,  2).equals(c)).filter(b -> b).findAny().orElse(false);
+		
+		if(!validFirstDigit && !validDoubleDigits){
 			return false;
 		}
 

--- a/src/test/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidatorTest.java
+++ b/src/test/java/com/premiumminds/webapp/wicket/validators/PortugueseNIFValidatorTest.java
@@ -92,4 +92,14 @@ public class PortugueseNIFValidatorTest {
 		assertEquals(1, validatable.getErrors().size());
 	}
 
+	@Test
+	public void testValidDoubleDigit() {
+		IValidator<String> validator = new PortugueseNIFValidator();
+		
+		Validatable<String> validatable = new Validatable<String>("451234561");
+		validator.validate(validatable);
+		
+		assertEquals(0, validatable.getErrors().size());
+
+	}
 }


### PR DESCRIPTION
https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal#Constitui%C3%A7%C3%A3o_e_interpreta%C3%A7%C3%A3o

O NIF pode pertencer a uma de várias gamas de números, definidas pelos dígitos iniciais, com as seguintes interpretações[1]:

1 a 3: Pessoa singular, o 3 ainda não está atribuido;[2]
45: Pessoa singular. Os algarismos iniciais "45" correspondem aos cidadãos não residentes que apenas obtenham em território português rendimentos sujeitos a retenção na fonte a título definitivo;[2]
5: Pessoa colectiva obrigada a registo no Registo Nacional de Pessoas Colectivas;[3]
6: Organismo da Administração Pública Central, Regional ou Local;
70, 74 e 75: Herança Indivisa, em que o autor da sucessão não era empresário individual, ou Herança Indivisa em que o cônjuge sobrevivo tem rendimentos comerciais;
71: Não residentes colectivos sujeitos a retenção na fonte a título definitivo;
72: Fundos de investimento;
77: Atribuição Oficiosa de NIF de sujeito passivo (entidades que não requerem NIF junto do RNPC);
78: Atribuição oficiosa a não residentes abrangidos pelo processo VAT REFUND;
79: Regime excepcional - Expo 98;
8: "empresário em nome individual" (actualmente obsoleto, já não é utilizado nem é válido);
90 e 91: Condomínios, Sociedade Irregulares, Heranças Indivisas cujo autor da sucessão era empresário individual;
98: Não residentes sem estabelecimento estável;
99: Sociedades civis sem personalidade jurídica.